### PR TITLE
use exec instead subshell for editor

### DIFF
--- a/bin/t_time_tracker
+++ b/bin/t_time_tracker
@@ -91,8 +91,7 @@ parser   = OptionParser.new do |opt|
     end
     
     # batch edit the logs
-    `#{ENV['EDITOR']} #{@tracker.directory}`
-    exit
+    exec(ENV['EDITOR'], @tracker.directory)
   end
 end
 


### PR DESCRIPTION
Then trying to exec editor (vim in my case) I got an error:

    $ LC_ALL=C tt -e
    opening /home/lzap/.ttimetracker
    Vim: Warning: Output is not to a terminal

I looked into the codebase and you are spawning a subshell, that's not
necessary, this patch uses Kernel exec instead. That's cleaner and faster.